### PR TITLE
Remove unused parameters from catch statements

### DIFF
--- a/happly.h
+++ b/happly.h
@@ -1030,7 +1030,7 @@ public:
 
         return getDataFromListPropertyRecursive<T, OppsignType>(prop.get());
 
-      } catch (const std::runtime_error& new_e) {
+      } catch (const std::runtime_error&) {
         throw orig_e;
       }
 
@@ -1492,7 +1492,7 @@ public:
       for (const std::string& p : std::vector<std::string>{"vertex_indices", "vertex_index"}) {
         try {
           return getElement(f).getListPropertyAnySign<T>(p);
-        } catch (const std::runtime_error& e) {
+        } catch (const std::runtime_error&) {
           // that's fine
         }
       }


### PR DESCRIPTION
I totally understand if these changes here are not something you want. Thanks for sharing happly!

MSVC gives a warning for some unused parameters in catch statements:

```
third_party\happly\happly.h(1496,44): Warning C4101: 'e': unreferenced local variable
third_party\happly\happly.h(1034,42): Warning C4101: 'new_e': unreferenced local variable
```

Interestingly, clang (9.0 anyway) doesn't seem to throw an unused parameter warning for catch statements. None-the-less, I normally like having the unused parameter warning enabled, so I wanted to fix these two.

I did notice that none of the disabled warnings for clang were getting triggered, I would suggest enabling all those warnings again and can also add that to this PR if you would like. (That's just my opinion of course.)