### PR TITLE
bugfix: skip empty lines

### DIFF
--- a/happly.h
+++ b/happly.h
@@ -39,6 +39,7 @@ SOFTWARE.
 
   Significant changes to the file recorded here.
 
+  - Version 5 (Aug 22, 2020)      Minor: skip blank lines before properties in ASCII files
   - Version 4 (Sep 11, 2019)      Change internal list format to be flat. Other small perf fixes and cleanup.
   - Version 3 (Aug 1, 2019)       Add support for big endian and obj_info
   - Version 2 (July 20, 2019)     Catch exceptions by const reference.


### PR DESCRIPTION
some ply files have empty lines before vertices list. This code is added to skip empty lines. Without this few lines, happly will parse empty lines as empty entries and valid vertices lines at the end of the list will not be parsed.