### PR TITLE
Add specializations of swapEndian to avoid compiler warnings

### DIFF
--- a/happly.h
+++ b/happly.h
@@ -238,6 +238,10 @@ T swapEndian(T val) {
   return val;
 }
 
+// The following specializations for single-byte types are used to avoid compiler warnings.
+template <> int8_t swapEndian<int8_t>(int8_t val) { return val; }
+template <> uint8_t swapEndian<uint8_t>(uint8_t val) { return val; }
+
 
 // Unpack flattened list from the convention used in TypedListProperty
 template <typename T>


### PR DESCRIPTION
I was running into the following compiler warnings:

```
happly.h(235): warning: pointless comparison of unsigned integer with zero
          detected during:
            instantiation of "T happly::<unnamed>::swapEndian(T) [with T=uint8_t]"
(536): here
            instantiation of "void happly::TypedListProperty<T>::readNextBigEndian(std::istream &) [with T=uint8_t]"
(425): here
            instantiation of "happly::TypedListProperty<T>::TypedListProperty(const std::__cxx11::string &, int) [with T=uint8_t]"
(691): here

happly.h(235): warning: pointless comparison of unsigned integer with zero
          detected during:
            instantiation of "T happly::<unnamed>::swapEndian(T) [with T=int8_t]"
(536): here
            instantiation of "void happly::TypedListProperty<T>::readNextBigEndian(std::istream &) [with T=int8_t]"
(425): here
            instantiation of "happly::TypedListProperty<T>::TypedListProperty(const std::__cxx11::string &, int) [with T=int8_t]"
(720): here
```

These can be fixed by adding explicit template specializations as proposed by this pull request.


Context:
I am using nvcc 11.1 (Nvidia Cuda Compiler). There was another issue where I had to replace `dynamic_cast<TypedProperty<T>*>` with a C-style cast, but I am not sure if this is a problem with the code or the compiler.

