### PR TITLE
Explicitly unwrap unique_ptrs in dynamic_casts

### DIFF
--- a/happly.h
+++ b/happly.h
@@ -951,7 +951,7 @@ public:
 
     // Find the property
     std::unique_ptr<Property>& prop = getPropertyPtr(propertyName);
-    TypedProperty<T>* castedProp = dynamic_cast<TypedProperty<T>*>(prop);
+    TypedProperty<T>* castedProp = dynamic_cast<TypedProperty<T>*>(prop.get());
     if (castedProp) {
       return castedProp->data;
     }
@@ -994,7 +994,7 @@ public:
 
     // Find the property
     std::unique_ptr<Property>& prop = getPropertyPtr(propertyName);
-    TypedListProperty<T>* castedProp = dynamic_cast<TypedListProperty<T>*>(prop);
+    TypedListProperty<T>* castedProp = dynamic_cast<TypedListProperty<T>*>(prop.get());
     if (castedProp) {
       return unflattenList(castedProp->flattenedData, castedProp->flattenedIndexStart);
     }


### PR DESCRIPTION
This change explicitly calls `get()` on `unique_ptr`s when they are used in a `dynamic_cast`. This must be the intended behavior, because the target type of the casts is a regular pointer and not a smart pointer, but I am not sure by which C++ mechanism this is currently achieved (i.e. `unique_ptr` should not be implicitly convertible to a regular pointer and the [documentation](https://en.cppreference.com/w/cpp/language/dynamic_cast) for `dynamic_cast` does not mention smart pointers at all).

`get()` is [safe](https://en.cppreference.com/w/cpp/memory/unique_ptr/get) to call on empty `unique_ptr`s, in which case it returns `nullptr`. Please also refer to [line 821](https://github.com/nmwsharp/happly/blob/cfa2611550bc7da65855a78af0574b65deb81766/happly.h#L821) where it is already called explicitly.

This fixes the compilation errors mentioned in #30 and the code now compiles using nvcc (tested with version 11.1).

