### PR TITLE
add support for 64 bit integer

### DIFF
--- a/happly.h
+++ b/happly.h
@@ -518,11 +518,11 @@ public:
     // Read the size of the list
     size_t count = 0;
     stream.read(((char*)&count), listCountBytes);
-    if (listCountBytes == 8) {
+    if (listCountBytes == sizeof(uint64_t)) {
       count = (size_t)swapEndian((uint64_t)count);
-    } else if (listCountBytes == 4) {
+    } else if (listCountBytes == sizeof(uint32_t)) {
       count = (size_t)swapEndian((uint32_t)count);
-    } else if (listCountBytes == 2) {
+    } else if (listCountBytes == sizeof(uint16_t)) {
       count = (size_t)swapEndian((uint16_t)count);
     }
 

--- a/happly.h
+++ b/happly.h
@@ -76,6 +76,8 @@ template<> inline std::string typeName<int16_t>()           { return "short";   
 template<> inline std::string typeName<uint16_t>()          { return "ushort";  }
 template<> inline std::string typeName<int32_t>()           { return "int";     }
 template<> inline std::string typeName<uint32_t>()          { return "uint";    }
+template<> inline std::string typeName<int64_t>()           { return "int64";     }
+template<> inline std::string typeName<uint64_t>()          { return "uint64";    }
 template<> inline std::string typeName<float>()             { return "float";   }
 template<> inline std::string typeName<double>()            { return "double";  }
 
@@ -675,13 +677,15 @@ inline std::unique_ptr<Property> createPropertyWithType(const std::string& name,
   if (isList) {
     if (listCountTypeStr == "uchar" || listCountTypeStr == "uint8" || listCountTypeStr == "char" ||
         listCountTypeStr == "int8") {
-      listCountBytes = 1;
+      listCountBytes = sizeof(uint8_t);
     } else if (listCountTypeStr == "ushort" || listCountTypeStr == "uint16" || listCountTypeStr == "short" ||
                listCountTypeStr == "int16") {
-      listCountBytes = 2;
+      listCountBytes = sizeof(uint16_t);
     } else if (listCountTypeStr == "uint" || listCountTypeStr == "uint32" || listCountTypeStr == "int" ||
                listCountTypeStr == "int32") {
-      listCountBytes = 4;
+      listCountBytes = sizeof(uint32_t);
+    } else if (listCountTypeStr == "uint64" || listCountTypeStr == "int64") {
+      listCountBytes = sizeof(uint64_t);
     } else {
       throw std::runtime_error("Unrecognized list count type: " + listCountTypeStr);
     }
@@ -716,6 +720,15 @@ inline std::unique_ptr<Property> createPropertyWithType(const std::string& name,
     }
   }
 
+  // 64 bit unsigned
+  else if (typeStr == "uint64") {
+    if (isList) {
+      return std::unique_ptr<Property>(new TypedListProperty<uint64_t>(name, listCountBytes));
+    } else {
+      return std::unique_ptr<Property>(new TypedProperty<uint64_t>(name));
+    }
+  }
+
   // = Signed int
 
   // 8 bit signed
@@ -742,6 +755,15 @@ inline std::unique_ptr<Property> createPropertyWithType(const std::string& name,
       return std::unique_ptr<Property>(new TypedListProperty<int32_t>(name, listCountBytes));
     } else {
       return std::unique_ptr<Property>(new TypedProperty<int32_t>(name));
+    }
+  }
+
+  // 64 bit signed
+  else if (typeStr == "int64") {
+    if (isList) {
+      return std::unique_ptr<Property>(new TypedListProperty<int64_t>(name, listCountBytes));
+    } else {
+      return std::unique_ptr<Property>(new TypedProperty<int64_t>(name));
     }
   }
 
@@ -1612,7 +1634,7 @@ public:
 
   /**
    * @brief Common-case helper to set face indices. Creates a face element if needed. The input type will be casted to a
-   * 32 bit integer of the same signedness.
+   * 64 bit integer of the same signedness.
    *
    * @param indices The indices into the vertex list around each face.
    */
@@ -1627,8 +1649,8 @@ public:
       addElement(faceName, N);
     }
 
-    // Cast to 32 bit
-    typedef typename std::conditional<std::is_signed<T>::value, int32_t, uint32_t>::type IndType;
+    // Cast to 64 bit
+    typedef typename std::conditional<std::is_signed<T>::value, int64_t, uint64_t>::type IndType;
     std::vector<std::vector<IndType>> intInds;
     for (std::vector<T>& l : indices) {
       std::vector<IndType> thisInds;
@@ -1637,7 +1659,7 @@ public:
         if (valConverted != val) {
           throw std::runtime_error("Index value " + std::to_string(val) +
                                    " could not be converted to a .ply integer without loss of data. Note that .ply "
-                                   "only supports 32-bit ints.");
+                                   "only supports 64-bit ints.");
         }
         thisInds.push_back(valConverted);
       }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,9 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+### Find dependencies
+find_package(Boost QUIET)
+
 ### Compile options
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   # using Clang (linux or apple) or GCC
@@ -87,7 +90,10 @@ target_link_libraries(ply-test gtest)
 
 target_include_directories(ply-test PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/..")
 
+if(Boost_FOUND)
+target_compile_definitions(ply-test PRIVATE HAS_BOOST)
+endif()
+
 # Add cmake test target  ("make test")
 enable_testing()
 add_test(MainTest ply-test)
-

--- a/test/CMakeLists.txt.in
+++ b/test/CMakeLists.txt.in
@@ -5,7 +5,7 @@ project(googletest-download NONE)
 include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
-  GIT_TAG           master
+  GIT_TAG           main
   SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
   BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""

--- a/test/main_test.cpp
+++ b/test/main_test.cpp
@@ -4,6 +4,10 @@
 #include <string>
 #include <chrono>
 #include <random>
+#ifdef HAS_BOOST
+#include <boost/multiprecision/cpp_int.hpp>
+using namespace boost::multiprecision;
+#endif
 
 #include "gtest/gtest.h"
 
@@ -1141,13 +1145,15 @@ TEST(TypePromotionTest, FaceIndSign) {
   EXPECT_NE(faceIndsU, faceIndGetU);
 }
 
+#ifdef HAS_BOOST
 TEST(TypePromotionTest, FaceIndThrow) {
 
   happly::PLYData ply;
   ply.addElement("face", 3);
-  std::vector<std::vector<uint64_t>> faceInds{{1, 3, 1LL << 40}, {0, 2, 4, 5}, {1, 1, 1}};
+  std::vector<std::vector<uint128_t>> faceInds{{1, 3, 1LL << 40}, {0, 2, 4, 5}, {1, 1, 1}};
   EXPECT_THROW(ply.getElement("face").addListProperty("vertex_indices", faceInds), std::runtime_error);
 }
+#endif
 
 // === Test reading mesh-like files
 TEST(MeshTest, ReadWriteASCIIMesh) {


### PR DESCRIPTION
This adds type support for `int64_t` and `uint64_t` with their equivalent PLY types `int64` and `uint64`.

There is no standard `uint128_t` for testing the exception in `addFaceIndices`. This requires boost and is therefore optional.