### PR TITLE
Code cleanup

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,6 @@ name: linux
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -2,7 +2,6 @@ name: macOS
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,6 @@ name: windows
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/happly.h
+++ b/happly.h
@@ -486,9 +486,9 @@ public:
     std::size_t afterSize = currSize + count;
     flattenedData.resize(afterSize);
     for (std::size_t iFlat = currSize; iFlat < afterSize; ++iFlat) {
-      std::istringstream iss(tokens[currEntry]);
+      std::istringstream iss_tmp(tokens[currEntry]);
       typename SerializeType<T>::type tmp; // usually the same type as T
-      iss >> tmp;
+      iss_tmp >> tmp;
       flattenedData[iFlat] = tmp;
       currEntry++;
     }

--- a/happly.h
+++ b/happly.h
@@ -843,6 +843,7 @@ public:
    */
   std::vector<std::string> getPropertyNames() {
     std::vector<std::string> names;
+    names.reserve(properties.size());
     for (std::unique_ptr<Property>& p : properties) {
       names.push_back(p->name);
     }
@@ -1431,6 +1432,7 @@ public:
    */
   std::vector<std::string> getElementNames() {
     std::vector<std::string> names;
+    names.reserve(elements.size());
     for (Element& e : elements) {
       names.push_back(e.name);
     }

--- a/happly.h
+++ b/happly.h
@@ -226,7 +226,7 @@ namespace {
  */
 bool isLittleEndian() {
   int32_t oneVal = 0x1;
-  const auto numPtr = (char*)&oneVal;
+  const auto numPtr = reinterpret_cast<char*>(&oneVal);
   return (numPtr[0] == 1);
 }
 
@@ -339,7 +339,7 @@ public:
    */
   void readNext(std::istream& stream) override {
     data.emplace_back();
-    stream.read((char*)&data.back(), sizeof(T));
+    stream.read(reinterpret_cast<char*>(&data.back()), sizeof(T));
   }
 
   /**
@@ -349,7 +349,7 @@ public:
    */
   void readNextBigEndian(std::istream& stream) override {
     data.emplace_back();
-    stream.read((char*)&data.back(), sizeof(T));
+    stream.read(reinterpret_cast<char*>(&data.back()), sizeof(T));
     data.back() = swapEndian(data.back());
   }
 
@@ -380,7 +380,7 @@ public:
    * @param iElement index of the element to write.
    */
   void writeDataBinary(std::ostream& outStream, std::size_t iElement) override {
-    outStream.write((char*)&data[iElement], sizeof(T));
+    outStream.write(reinterpret_cast<char*>(&data[iElement]), sizeof(T));
   }
 
   /**
@@ -391,7 +391,7 @@ public:
    */
   void writeDataBinaryBigEndian(std::ostream& outStream, std::size_t iElement) override {
     auto value = swapEndian(data[iElement]);
-    outStream.write((char*)&value, sizeof(T));
+    outStream.write(reinterpret_cast<char*>(&value), sizeof(T));
   }
 
   /**
@@ -504,14 +504,14 @@ public:
 
     // Read the size of the list
     std::size_t count = 0;
-    stream.read(((char*)&count), listCountBytes);
+    stream.read(reinterpret_cast<char*>(&count), listCountBytes);
 
     // Read list elements
     std::size_t currSize = flattenedData.size();
     std::size_t afterSize = currSize + count;
     flattenedData.resize(afterSize);
     if (count > 0) {
-      stream.read((char*)&flattenedData[currSize], count * sizeof(T));
+      stream.read(reinterpret_cast<char*>(&flattenedData[currSize]), count * sizeof(T));
     }
     flattenedIndexStart.emplace_back(afterSize);
   }
@@ -525,13 +525,13 @@ public:
 
     // Read the size of the list
     std::size_t count = 0;
-    stream.read(((char*)&count), listCountBytes);
+    stream.read(reinterpret_cast<char*>(&count), listCountBytes);
     if (listCountBytes == 8) {
-      count = (size_t)swapEndian((uint64_t)count);
+      count = static_cast<std::size_t>(swapEndian(static_cast<uint64_t>(count)));
     } else if (listCountBytes == 4) {
-      count = (size_t)swapEndian((uint32_t)count);
+      count = static_cast<std::size_t>(swapEndian(static_cast<uint32_t>(count)));
     } else if (listCountBytes == 2) {
-      count = (size_t)swapEndian((uint16_t)count);
+      count = static_cast<std::size_t>(swapEndian(static_cast<uint16_t>(count)));
     }
 
     // Read list elements
@@ -539,7 +539,7 @@ public:
     std::size_t afterSize = currSize + count;
     flattenedData.resize(afterSize);
     if (count > 0) {
-      stream.read((char*)&flattenedData[currSize], count * sizeof(T));
+      stream.read(reinterpret_cast<char*>(&flattenedData[currSize]), count * sizeof(T));
     }
     flattenedIndexStart.emplace_back(afterSize);
 
@@ -601,8 +601,8 @@ public:
     }
     auto count = static_cast<uint8_t>(dataCount);
 
-    outStream.write((char*)&count, sizeof(uint8_t));
-    outStream.write((char*)&flattenedData[dataStart], count * sizeof(T));
+    outStream.write(reinterpret_cast<char*>(&count), sizeof(uint8_t));
+    outStream.write(reinterpret_cast<char*>(&flattenedData[dataStart]), count * sizeof(T));
   }
 
   /**
@@ -623,10 +623,10 @@ public:
     }
     auto count = static_cast<uint8_t>(dataCount);
 
-    outStream.write((char*)&count, sizeof(uint8_t));
+    outStream.write(reinterpret_cast<char*>(&count), sizeof(uint8_t));
     for (std::size_t iFlat = dataStart; iFlat < dataEnd; ++iFlat) {
       T value = swapEndian(flattenedData[iFlat]);
-      outStream.write((char*)&value, sizeof(T));
+      outStream.write(reinterpret_cast<char*>(&value), sizeof(T));
     }
   }
 

--- a/happly.h
+++ b/happly.h
@@ -308,14 +308,14 @@ public:
     }
   };
 
-  virtual ~TypedProperty() override{};
+  ~TypedProperty() override = default;
 
   /**
    * @brief Reserve memory.
    *
    * @param capacity Expected number of elements.
    */
-  virtual void reserve(size_t capacity) override { data.reserve(capacity); }
+  void reserve(std::size_t capacity) override { data.reserve(capacity); }
 
   /**
    * @brief (ASCII reading) Parse out the next value of this property from a list of tokens.
@@ -323,7 +323,7 @@ public:
    * @param tokens The list of property tokens for the element.
    * @param currEntry Index in to tokens, updated after this property is read.
    */
-  virtual void parseNext(const std::vector<std::string>& tokens, size_t& currEntry) override {
+  void parseNext(const std::vector<std::string>& tokens, std::size_t& currEntry) override {
     data.emplace_back();
     std::istringstream iss(tokens[currEntry]);
     typename SerializeType<T>::type tmp; // usually the same type as T
@@ -337,7 +337,7 @@ public:
    *
    * @param stream Stream to read from.
    */
-  virtual void readNext(std::istream& stream) override {
+  void readNext(std::istream& stream) override {
     data.emplace_back();
     stream.read((char*)&data.back(), sizeof(T));
   }
@@ -347,7 +347,7 @@ public:
    *
    * @param stream Stream to read from.
    */
-  virtual void readNextBigEndian(std::istream& stream) override {
+  void readNextBigEndian(std::istream& stream) override {
     data.emplace_back();
     stream.read((char*)&data.back(), sizeof(T));
     data.back() = swapEndian(data.back());
@@ -358,7 +358,7 @@ public:
    *
    * @param outStream Stream to write to.
    */
-  virtual void writeHeader(std::ostream& outStream) override {
+  void writeHeader(std::ostream& outStream) override {
     outStream << "property " << typeName<T>() << " " << name << "\n";
   }
 
@@ -368,7 +368,7 @@ public:
    * @param outStream Stream to write to.
    * @param iElement index of the element to write.
    */
-  virtual void writeDataASCII(std::ostream& outStream, size_t iElement) override {
+  void writeDataASCII(std::ostream& outStream, std::size_t iElement) override {
     outStream.precision(std::numeric_limits<T>::max_digits10);
     outStream << static_cast<typename SerializeType<T>::type>(data[iElement]); // case is usually a no-op
   }
@@ -379,7 +379,7 @@ public:
    * @param outStream Stream to write to.
    * @param iElement index of the element to write.
    */
-  virtual void writeDataBinary(std::ostream& outStream, size_t iElement) override {
+  void writeDataBinary(std::ostream& outStream, std::size_t iElement) override {
     outStream.write((char*)&data[iElement], sizeof(T));
   }
 
@@ -389,7 +389,7 @@ public:
    * @param outStream Stream to write to.
    * @param iElement index of the element to write.
    */
-  virtual void writeDataBinaryBigEndian(std::ostream& outStream, size_t iElement) override {
+  void writeDataBinaryBigEndian(std::ostream& outStream, std::size_t iElement) override {
     auto value = swapEndian(data[iElement]);
     outStream.write((char*)&value, sizeof(T));
   }
@@ -407,7 +407,7 @@ public:
    *
    * @return
    */
-  virtual std::string propertyTypeName() override { return typeName<T>(); }
+  std::string propertyTypeName() override { return typeName<T>(); }
 
   /**
    * @brief The actual data contained in the property
@@ -457,14 +457,14 @@ public:
     }
   };
 
-  virtual ~TypedListProperty() override{};
+  ~TypedListProperty() override= default;
 
   /**
    * @brief Reserve memory.
    *
    * @param capacity Expected number of elements.
    */
-  virtual void reserve(size_t capacity) override {
+  void reserve(std::size_t capacity) override {
     flattenedData.reserve(3 * capacity); // optimize for triangle meshes
     flattenedIndexStart.reserve(capacity + 1);
   }
@@ -475,7 +475,7 @@ public:
    * @param tokens The list of property tokens for the element.
    * @param currEntry Index in to tokens, updated after this property is read.
    */
-  virtual void parseNext(const std::vector<std::string>& tokens, size_t& currEntry) override {
+  void parseNext(const std::vector<std::string>& tokens, std::size_t& currEntry) override {
 
     std::istringstream iss(tokens[currEntry]);
     std::size_t count;
@@ -500,7 +500,7 @@ public:
    *
    * @param stream Stream to read from.
    */
-  virtual void readNext(std::istream& stream) override {
+  void readNext(std::istream& stream) override {
 
     // Read the size of the list
     std::size_t count = 0;
@@ -521,7 +521,7 @@ public:
    *
    * @param stream Stream to read from.
    */
-  virtual void readNextBigEndian(std::istream& stream) override {
+  void readNextBigEndian(std::istream& stream) override {
 
     // Read the size of the list
     std::size_t count = 0;
@@ -554,7 +554,7 @@ public:
    *
    * @param outStream Stream to write to.
    */
-  virtual void writeHeader(std::ostream& outStream) override {
+  void writeHeader(std::ostream& outStream) override {
     // NOTE: We ALWAYS use uchar as the list count output type
     outStream << "property list uchar " << typeName<T>() << " " << name << "\n";
   }
@@ -611,9 +611,9 @@ public:
    * @param outStream Stream to write to.
    * @param iElement index of the element to write.
    */
-  virtual void writeDataBinaryBigEndian(std::ostream& outStream, size_t iElement) override {
-    size_t dataStart = flattenedIndexStart[iElement];
-    size_t dataEnd = flattenedIndexStart[iElement + 1];
+  void writeDataBinaryBigEndian(std::ostream& outStream, std::size_t iElement) override {
+    std::size_t dataStart = flattenedIndexStart[iElement];
+    std::size_t dataEnd = flattenedIndexStart[iElement + 1];
 
     // Get the number of list elements as a uchar, and ensure the value fits
     std::size_t dataCount = dataEnd - dataStart;
@@ -635,7 +635,7 @@ public:
    *
    * @return
    */
-  virtual size_t size() override { return flattenedIndexStart.size() - 1; }
+  std::size_t size() override { return flattenedIndexStart.size() - 1; }
 
 
   /**
@@ -643,7 +643,7 @@ public:
    *
    * @return
    */
-  virtual std::string propertyTypeName() override { return typeName<T>(); }
+  std::string propertyTypeName() override { return typeName<T>(); }
 
   /**
    * @brief The (flattened) data for the property, as formed by concatenating all of the individual element lists

--- a/happly.h
+++ b/happly.h
@@ -136,8 +136,8 @@ public:
    *
    * @param name_
    */
-  Property(const std::string& name_) : name(name_){};
-  virtual ~Property(){};
+  explicit Property(const std::string& name_) : name(name_){};
+  virtual ~Property()= default;
 
   std::string name;
 
@@ -289,7 +289,7 @@ public:
    *
    * @param name_
    */
-  TypedProperty(const std::string& name_) : Property(name_) {
+  explicit TypedProperty(const std::string& name_) : Property(name_) {
     if (typeName<T>() == "unknown") {
       // TODO should really be a compile-time error
       throw std::runtime_error("Attempted property type does not match any type defined by the .ply format.");
@@ -1294,7 +1294,7 @@ public:
    * @param filename The file to read from.
    * @param verbose If true, print useful info about the file to stdout
    */
-  PLYData(const std::string& filename, bool verbose = false) {
+  explicit PLYData(const std::string& filename, bool verbose = false) {
 
     using std::cout;
     using std::endl;
@@ -1322,7 +1322,7 @@ public:
    * @param inStream The stringstream to read from.
    * @param verbose If true, print useful info about the file to stdout
    */
-  PLYData(std::istream& inStream, bool verbose = false) {
+  explicit PLYData(std::istream& inStream, bool verbose = false) {
 
     using std::cout;
     using std::endl;

--- a/happly.h
+++ b/happly.h
@@ -256,9 +256,9 @@ std::vector<std::vector<T>> unflattenList(const std::vector<T>& flatList, const 
   }
 
   // Copy each sublist
-  for (size_t iOuter = 0; iOuter < outerCount; iOuter++) {
-    size_t iFlatStart = flatListStarts[iOuter];
-    size_t iFlatEnd = flatListStarts[iOuter + 1];
+  for (std::size_t iOuter = 0; iOuter < outerCount; iOuter++) {
+    std::size_t iFlatStart = flatListStarts[iOuter];
+    std::size_t iFlatEnd = flatListStarts[iOuter + 1];
     outLists[iOuter].insert(outLists[iOuter].begin(), flatList.begin() + iFlatStart, flatList.begin() + iFlatEnd);
   }
 
@@ -536,7 +536,7 @@ public:
     flattenedIndexStart.emplace_back(afterSize);
 
     // Swap endian order of list elements
-    for (size_t iFlat = currSize; iFlat < afterSize; iFlat++) {
+    for (std::size_t iFlat = currSize; iFlat < afterSize; iFlat++) {
       flattenedData[iFlat] = swapEndian(flattenedData[iFlat]);
     }
   }
@@ -570,7 +570,7 @@ public:
 
     outStream << dataCount;
     outStream.precision(std::numeric_limits<T>::max_digits10);
-    for (size_t iFlat = dataStart; iFlat < dataEnd; iFlat++) {
+    for (std::size_t iFlat = dataStart; iFlat < dataEnd; ++iFlat) {
       outStream << " " << static_cast<typename SerializeType<T>::type>(flattenedData[iFlat]); // cast is usually a no-op
     }
   }
@@ -616,7 +616,7 @@ public:
     uint8_t count = static_cast<uint8_t>(dataCount);
 
     outStream.write((char*)&count, sizeof(uint8_t));
-    for (size_t iFlat = dataStart; iFlat < dataEnd; iFlat++) {
+    for (std::size_t iFlat = dataStart; iFlat < dataEnd; ++iFlat) {
       T value = swapEndian(flattenedData[iFlat]);
       outStream.write((char*)&value, sizeof(T));
     }
@@ -872,7 +872,7 @@ public:
     }
 
     // If there is already some property with this name, remove it
-    for (size_t i = 0; i < properties.size(); i++) {
+    for (std::size_t i = 0; i < properties.size(); ++i) {
       if (properties[i]->name == propertyName) {
         properties.erase(properties.begin() + i);
         i--;
@@ -901,7 +901,7 @@ public:
     }
 
     // If there is already some property with this name, remove it
-    for (size_t i = 0; i < properties.size(); i++) {
+    for (std::size_t i = 0; i < properties.size(); ++i) {
       if (properties[i]->name == propertyName) {
         properties.erase(properties.begin() + i);
         i--;
@@ -1054,13 +1054,13 @@ public:
   void validate() {
 
     // Make sure no properties have duplicate names, and no names have whitespace
-    for (size_t iP = 0; iP < properties.size(); iP++) {
-      for (char c : properties[iP]->name) {
+    for (std::size_t iP = 0; iP < properties.size(); iP++) {
+      for (const char c : properties[iP]->name) {
         if (std::isspace(c)) {
           throw std::runtime_error("Ply validate: illegal whitespace in name " + properties[iP]->name);
         }
       }
-      for (size_t jP = iP + 1; jP < properties.size(); jP++) {
+      for (std::size_t jP = iP + 1; jP < properties.size(); jP++) {
         if (properties[iP]->name == properties[jP]->name) {
           throw std::runtime_error("Ply validate: multiple properties with name " + properties[iP]->name);
         }
@@ -1099,8 +1099,8 @@ public:
   void writeDataASCII(std::ostream& outStream) {
     // Question: what is the proper output for an element with no properties? Here, we write a blank line, so there is
     // one line per element no matter what.
-    for (size_t iE = 0; iE < count; iE++) {
-      for (size_t iP = 0; iP < properties.size(); iP++) {
+    for (std::size_t iE = 0; iE < count; ++iE) {
+      for (std::size_t iP = 0; iP < properties.size(); ++iP) {
         properties[iP]->writeDataASCII(outStream, iE);
         if (iP < properties.size() - 1) {
           outStream << " ";
@@ -1117,10 +1117,10 @@ public:
    *
    * @param outStream The stream to write to.
    */
-  void writeDataBinary(std::ostream& outStream) {
-    for (size_t iE = 0; iE < count; iE++) {
-      for (size_t iP = 0; iP < properties.size(); iP++) {
-        properties[iP]->writeDataBinary(outStream, iE);
+  void writeDataBinary(std::ostream& outStream) const {
+    for (std::size_t iE = 0; iE < count; ++iE) {
+      for (const auto & property : properties) {
+        property->writeDataBinary(outStream, iE);
       }
     }
   }
@@ -1132,10 +1132,10 @@ public:
    *
    * @param outStream The stream to write to.
    */
-  void writeDataBinaryBigEndian(std::ostream& outStream) {
-    for (size_t iE = 0; iE < count; iE++) {
-      for (size_t iP = 0; iP < properties.size(); iP++) {
-        properties[iP]->writeDataBinaryBigEndian(outStream, iE);
+  void writeDataBinaryBigEndian(std::ostream& outStream) const {
+    for (std::size_t iE = 0; iE < count; ++iE) {
+      for (const auto & property : properties) {
+        property->writeDataBinaryBigEndian(outStream, iE);
       }
     }
   }
@@ -1333,13 +1333,13 @@ public:
    */
   void validate() {
 
-    for (size_t iE = 0; iE < elements.size(); iE++) {
+    for (std::size_t iE = 0; iE < elements.size(); ++iE) {
       for (char c : elements[iE].name) {
         if (std::isspace(c)) {
           throw std::runtime_error("Ply validate: illegal whitespace in element name " + elements[iE].name);
         }
       }
-      for (size_t jE = iE + 1; jE < elements.size(); jE++) {
+      for (std::size_t jE = iE + 1; jE < elements.size(); ++jE) {
         if (elements[iE].name == elements[jE].name) {
           throw std::runtime_error("Ply validate: duplcate element name " + elements[iE].name);
         }
@@ -1455,7 +1455,7 @@ public:
     std::vector<double> zPos = getElement(vertexElementName).getProperty<double>("z");
 
     std::vector<std::array<double, 3>> result(xPos.size());
-    for (size_t i = 0; i < result.size(); i++) {
+    for (std::size_t i = 0; i < result.size(); ++i) {
       result[i][0] = xPos[i];
       result[i][1] = yPos[i];
       result[i][2] = zPos[i];
@@ -1478,7 +1478,7 @@ public:
     std::vector<unsigned char> b = getElement(vertexElementName).getProperty<unsigned char>("blue");
 
     std::vector<std::array<unsigned char, 3>> result(r.size());
-    for (size_t i = 0; i < result.size(); i++) {
+    for (std::size_t i = 0; i < result.size(); ++i) {
       result[i][0] = r[i];
       result[i][1] = g[i];
       result[i][2] = b[i];
@@ -1529,7 +1529,7 @@ public:
     std::vector<double> xPos(N);
     std::vector<double> yPos(N);
     std::vector<double> zPos(N);
-    for (size_t i = 0; i < vertexPositions.size(); i++) {
+    for (std::size_t i = 0; i < vertexPositions.size(); ++i) {
       xPos[i] = vertexPositions[i][0];
       yPos[i] = vertexPositions[i][1];
       zPos[i] = vertexPositions[i][2];
@@ -1560,7 +1560,7 @@ public:
     std::vector<unsigned char> r(N);
     std::vector<unsigned char> g(N);
     std::vector<unsigned char> b(N);
-    for (size_t i = 0; i < colors.size(); i++) {
+    for (std::size_t i = 0; i < colors.size(); ++i) {
       r[i] = colors[i][0];
       g[i] = colors[i][1];
       b[i] = colors[i][2];
@@ -1597,7 +1597,7 @@ public:
     std::vector<unsigned char> r(N);
     std::vector<unsigned char> g(N);
     std::vector<unsigned char> b(N);
-    for (size_t i = 0; i < colors.size(); i++) {
+    for (std::size_t i = 0; i < colors.size(); ++i) {
       r[i] = toChar(colors[i][0]);
       g[i] = toChar(colors[i][1]);
       b[i] = toChar(colors[i][2]);
@@ -1843,10 +1843,10 @@ private:
         std::cout << "  - Processing element: " << elem.name << std::endl;
       }
 
-      for (size_t iP = 0; iP < elem.properties.size(); iP++) {
+      for (std::size_t iP = 0; iP < elem.properties.size(); ++iP) {
         elem.properties[iP]->reserve(elem.count);
       }
-      for (size_t iEntry = 0; iEntry < elem.count; iEntry++) {
+      for (std::size_t iEntry = 0; iEntry < elem.count; ++iEntry) {
 
         string line;
         std::getline(inStream, line);
@@ -1860,9 +1860,9 @@ private:
         }
 
         vector<string> tokens = tokenSplit(line);
-        size_t iTok = 0;
-        for (size_t iP = 0; iP < elem.properties.size(); iP++) {
-          elem.properties[iP]->parseNext(tokens, iTok);
+        std::size_t iTok = 0;
+        for (const auto & property : elem.properties) {
+          property->parseNext(tokens, iTok);
         }
       }
     }
@@ -1890,12 +1890,12 @@ private:
         std::cout << "  - Processing element: " << elem.name << std::endl;
       }
 
-      for (size_t iP = 0; iP < elem.properties.size(); iP++) {
+      for (std::size_t iP = 0; iP < elem.properties.size(); ++iP) {
         elem.properties[iP]->reserve(elem.count);
       }
-      for (size_t iEntry = 0; iEntry < elem.count; iEntry++) {
-        for (size_t iP = 0; iP < elem.properties.size(); iP++) {
-          elem.properties[iP]->readNext(inStream);
+      for (std::size_t iEntry = 0; iEntry < elem.count; ++iEntry) {
+        for (const auto & property : elem.properties) {
+          property->readNext(inStream);
         }
       }
     }
@@ -1923,12 +1923,12 @@ private:
         std::cout << "  - Processing element: " << elem.name << std::endl;
       }
 
-      for (size_t iP = 0; iP < elem.properties.size(); iP++) {
+      for (std::size_t iP = 0; iP < elem.properties.size(); ++iP) {
         elem.properties[iP]->reserve(elem.count);
       }
-      for (size_t iEntry = 0; iEntry < elem.count; iEntry++) {
-        for (size_t iP = 0; iP < elem.properties.size(); iP++) {
-          elem.properties[iP]->readNextBigEndian(inStream);
+      for (std::size_t iEntry = 0; iEntry < elem.count; ++iEntry) {
+        for (const auto & property : elem.properties) {
+          property->readNextBigEndian(inStream);
         }
       }
     }

--- a/happly.h
+++ b/happly.h
@@ -660,7 +660,7 @@ public:
   /**
    * @brief The number of bytes used to store the count for lists of data.
    */
-  int listCountBytes = -1;
+  int listCountBytes{-1};
 };
 
 

--- a/happly.h
+++ b/happly.h
@@ -485,7 +485,7 @@ public:
     const std::size_t currSize = flattenedData.size();
     std::size_t afterSize = currSize + count;
     flattenedData.resize(afterSize);
-    for (std::size_t iFlat = currSize; iFlat < afterSize; iFlat++) {
+    for (std::size_t iFlat = currSize; iFlat < afterSize; ++iFlat) {
       std::istringstream iss(tokens[currEntry]);
       typename SerializeType<T>::type tmp; // usually the same type as T
       iss >> tmp;

--- a/happly.h
+++ b/happly.h
@@ -63,9 +63,17 @@ SOFTWARE.
 // General namespace wrapping all Happly things.
 namespace happly {
 
-// Enum specifying binary or ASCII filetypes. Binary can be little-endian
-// (default) or big endian.
-enum class DataFormat { ASCII, Binary, BinaryBigEndian };
+/**
+ * @brief Enum specifying the data format for PLY files.
+ * 
+ * The PLY format supports both ASCII and binary encodings. Binary files can be stored
+ * in either little-endian (default) or big-endian byte order.
+ */
+enum class DataFormat { 
+  ASCII,            ///< ASCII text format
+  Binary,           ///< Binary format with little-endian byte order (default)
+  BinaryBigEndian   ///< Binary format with big-endian byte order
+};
 
 // Type name strings
 // clang-format off
@@ -225,7 +233,7 @@ bool isLittleEndian() {
 /**
  * Swap endianness.
  *
- * @param value Value to swap.
+ * @param val Value to swap.
  *
  * @return Swapped value.
  */

--- a/happly.h
+++ b/happly.h
@@ -700,27 +700,27 @@ inline std::unique_ptr<Property> createPropertyWithType(const std::string& name,
   // 8 bit unsigned
   if (typeStr == "uchar" || typeStr == "uint8") {
     if (isList) {
-      return std::unique_ptr<Property>(new TypedListProperty<uint8_t>(name, listCountBytes));
+      return std::make_unique<TypedListProperty<uint8_t>>(name, listCountBytes);
     } else {
-      return std::unique_ptr<Property>(new TypedProperty<uint8_t>(name));
+      return std::make_unique<TypedProperty<uint8_t>>(name);
     }
   }
 
   // 16 bit unsigned
   else if (typeStr == "ushort" || typeStr == "uint16") {
     if (isList) {
-      return std::unique_ptr<Property>(new TypedListProperty<uint16_t>(name, listCountBytes));
+      return std::make_unique<TypedListProperty<uint16_t>>(name, listCountBytes);
     } else {
-      return std::unique_ptr<Property>(new TypedProperty<uint16_t>(name));
+      return std::make_unique<TypedProperty<uint16_t>>(name);
     }
   }
 
   // 32 bit unsigned
   else if (typeStr == "uint" || typeStr == "uint32") {
     if (isList) {
-      return std::unique_ptr<Property>(new TypedListProperty<uint32_t>(name, listCountBytes));
+      return std::make_unique<TypedListProperty<uint32_t>>(name, listCountBytes);
     } else {
-      return std::unique_ptr<Property>(new TypedProperty<uint32_t>(name));
+      return std::make_unique<TypedProperty<uint32_t>>(name);
     }
   }
 
@@ -729,27 +729,27 @@ inline std::unique_ptr<Property> createPropertyWithType(const std::string& name,
   // 8 bit signed
   if (typeStr == "char" || typeStr == "int8") {
     if (isList) {
-      return std::unique_ptr<Property>(new TypedListProperty<int8_t>(name, listCountBytes));
+      return std::make_unique<TypedListProperty<int8_t>>(name, listCountBytes);
     } else {
-      return std::unique_ptr<Property>(new TypedProperty<int8_t>(name));
+      return std::make_unique<TypedProperty<int8_t>>(name);
     }
   }
 
   // 16 bit signed
   else if (typeStr == "short" || typeStr == "int16") {
     if (isList) {
-      return std::unique_ptr<Property>(new TypedListProperty<int16_t>(name, listCountBytes));
+      return std::make_unique<TypedListProperty<int16_t>>(name, listCountBytes);
     } else {
-      return std::unique_ptr<Property>(new TypedProperty<int16_t>(name));
+      return std::make_unique<TypedProperty<int16_t>>(name);
     }
   }
 
   // 32 bit signed
   else if (typeStr == "int" || typeStr == "int32") {
     if (isList) {
-      return std::unique_ptr<Property>(new TypedListProperty<int32_t>(name, listCountBytes));
+      return std::make_unique<TypedListProperty<int32_t>>(name, listCountBytes);
     } else {
-      return std::unique_ptr<Property>(new TypedProperty<int32_t>(name));
+      return std::make_unique<TypedProperty<int32_t>>(name);
     }
   }
 
@@ -758,18 +758,18 @@ inline std::unique_ptr<Property> createPropertyWithType(const std::string& name,
   // 32 bit float
   else if (typeStr == "float" || typeStr == "float32") {
     if (isList) {
-      return std::unique_ptr<Property>(new TypedListProperty<float>(name, listCountBytes));
+      return std::make_unique<TypedListProperty<float>>(name, listCountBytes);
     } else {
-      return std::unique_ptr<Property>(new TypedProperty<float>(name));
+      return std::make_unique<TypedProperty<float>>(name);
     }
   }
 
   // 64 bit float
   else if (typeStr == "double" || typeStr == "float64") {
     if (isList) {
-      return std::unique_ptr<Property>(new TypedListProperty<double>(name, listCountBytes));
+      return std::make_unique<TypedListProperty<double>>(name, listCountBytes);
     } else {
-      return std::unique_ptr<Property>(new TypedProperty<double>(name));
+      return std::make_unique<TypedProperty<double>>(name);
     }
   }
 

--- a/happly.h
+++ b/happly.h
@@ -649,7 +649,7 @@ public:
    * @brief The (flattened) data for the property, as formed by concatenating all of the individual element lists
    * together.
    */
-  std::vector<T> flattenedData;
+  std::vector<T> flattenedData{};
 
   /**
    * @brief Indices in to flattenedData. The i'th element gives the index in to flattenedData where the element's data

--- a/happly.h
+++ b/happly.h
@@ -226,7 +226,7 @@ namespace {
  */
 bool isLittleEndian() {
   int32_t oneVal = 0x1;
-  char* numPtr = (char*)&oneVal;
+  const auto numPtr = (char*)&oneVal;
   return (numPtr[0] == 1);
 }
 
@@ -239,7 +239,7 @@ bool isLittleEndian() {
  */
 template <typename T>
 T swapEndian(T val) {
-  char* bytes = reinterpret_cast<char*>(&val);
+  const auto bytes = reinterpret_cast<char*>(&val);
   for (unsigned int i = 0; i < sizeof(val) / 2; i++) {
     std::swap(bytes[sizeof(val) - 1 - i], bytes[i]);
   }
@@ -253,8 +253,8 @@ template <> uint8_t swapEndian<uint8_t>(uint8_t val) { return val; }
 
 // Unpack flattened list from the convention used in TypedListProperty
 template <typename T>
-std::vector<std::vector<T>> unflattenList(const std::vector<T>& flatList, const std::vector<size_t> flatListStarts) {
-  size_t outerCount = flatListStarts.size() - 1;
+std::vector<std::vector<T>> unflattenList(const std::vector<T>& flatList, const std::vector<std::size_t>& flatListStarts) {
+  std::size_t outerCount = flatListStarts.size() - 1;
 
   // Put the output here
   std::vector<std::vector<T>> outLists(outerCount);
@@ -823,8 +823,8 @@ public:
    * @return Whether the target property exists.
    */
   template <class T>
-  bool hasPropertyType(const std::string& target) {
-    for (std::unique_ptr<Property>& prop : properties) {
+  bool hasPropertyType(const std::string& target) const {
+    for (const std::unique_ptr<Property>& prop : properties) {
       if (prop->name == target) {
         TypedProperty<T>* castedProp = dynamic_cast<TypedProperty<T>*>(prop.get());
         if (castedProp) {
@@ -1059,7 +1059,7 @@ public:
   /**
    * @brief Performs sanity checks on the element, throwing if any fail.
    */
-  void validate() {
+  void validate() const {
 
     // Make sure no properties have duplicate names, and no names have whitespace
     for (std::size_t iP = 0; iP < properties.size(); iP++) {
@@ -1076,9 +1076,9 @@ public:
     }
 
     // Make sure all properties have right length
-    for (size_t iP = 0; iP < properties.size(); iP++) {
-      if (properties[iP]->size() != count) {
-        throw std::runtime_error("Ply validate: property has wrong size. " + properties[iP]->name +
+    for (const auto & property : properties) {
+      if (property->size() != count) {
+        throw std::runtime_error("Ply validate: property has wrong size. " + property->name +
                                  " does not match element size.");
       }
     }
@@ -1104,7 +1104,7 @@ public:
    *
    * @param outStream The stream to write to.
    */
-  void writeDataASCII(std::ostream& outStream) {
+  void writeDataASCII(std::ostream& outStream) const {
     // Question: what is the proper output for an element with no properties? Here, we write a blank line, so there is
     // one line per element no matter what.
     for (std::size_t iE = 0; iE < count; ++iE) {
@@ -1525,8 +1525,8 @@ public:
    */
   void addVertexPositions(std::vector<std::array<double, 3>>& vertexPositions) {
 
-    std::string vertexName = "vertex";
-    size_t N = vertexPositions.size();
+    const std::string vertexName{"vertex"};
+    const std::size_t N = vertexPositions.size();
 
     // Create the element
     if (!hasElement(vertexName)) {
@@ -1556,8 +1556,8 @@ public:
    */
   void addVertexColors(std::vector<std::array<unsigned char, 3>>& colors) {
 
-    std::string vertexName = "vertex";
-    size_t N = colors.size();
+    const std::string vertexName = "vertex";
+    const std::size_t N = colors.size();
 
     // Create the element
     if (!hasElement(vertexName)) {
@@ -1627,8 +1627,8 @@ public:
   template <typename T>
   void addFaceIndices(std::vector<std::vector<T>>& indices) {
 
-    std::string faceName = "face";
-    size_t N = indices.size();
+    const std::string faceName = "face";
+    const std::size_t N = indices.size();
 
     // Create the element
     if (!hasElement(faceName)) {
@@ -1732,9 +1732,9 @@ private:
       std::getline(inStream, styleLine);
       vector<string> tokens = tokenSplit(styleLine);
       if (tokens.size() != 3) throw std::runtime_error("PLY parser: bad format line");
-      std::string formatStr = tokens[0];
-      std::string typeStr = tokens[1];
-      std::string versionStr = tokens[2];
+      const std::string& formatStr = tokens[0];
+      const std::string& typeStr = tokens[1];
+      const std::string& versionStr = tokens[2];
 
       // "format"
       if (formatStr != "format") throw std::runtime_error("PLY parser: bad format line");
@@ -1798,10 +1798,10 @@ private:
       else if (startsWith(line, "property list")) {
         vector<string> tokens = tokenSplit(line);
         if (tokens.size() != 5) throw std::runtime_error("PLY parser: Invalid property list line");
-        if (elements.size() == 0) throw std::runtime_error("PLY parser: Found property list without previous element");
-        string countType = tokens[2];
-        string type = tokens[3];
-        string name = tokens[4];
+        if (elements.empty()) throw std::runtime_error("PLY parser: Found property list without previous element");
+        const string& countType = tokens[2];
+        const string& type = tokens[3];
+        const string& name = tokens[4];
         elements.back().properties.push_back(createPropertyWithType(name, type, true, countType));
         if (verbose)
           cout << "    - Found list property: " << name << " (count type = " << countType << ", data type = " << type
@@ -1813,9 +1813,9 @@ private:
       else if (startsWith(line, "property")) {
         vector<string> tokens = tokenSplit(line);
         if (tokens.size() != 3) throw std::runtime_error("PLY parser: Invalid property line");
-        if (elements.size() == 0) throw std::runtime_error("PLY parser: Found property without previous element");
-        string type = tokens[1];
-        string name = tokens[2];
+        if (elements.empty()) throw std::runtime_error("PLY parser: Found property without previous element");
+        const string& type = tokens[1];
+        const string& name = tokens[2];
         elements.back().properties.push_back(createPropertyWithType(name, type, false, ""));
         if (verbose) cout << "    - Found property: " << name << " (type = " << type << ")" << endl;
         continue;

--- a/happly.h
+++ b/happly.h
@@ -599,7 +599,7 @@ public:
       throw std::runtime_error(
           "List property has an element with more entries than fit in a uchar. See note in README.");
     }
-    uint8_t count = static_cast<uint8_t>(dataCount);
+    auto count = static_cast<uint8_t>(dataCount);
 
     outStream.write((char*)&count, sizeof(uint8_t));
     outStream.write((char*)&flattenedData[dataStart], count * sizeof(T));
@@ -621,7 +621,7 @@ public:
       throw std::runtime_error(
           "List property has an element with more entries than fit in a uchar. See note in README.");
     }
-    uint8_t count = static_cast<uint8_t>(dataCount);
+    auto count = static_cast<uint8_t>(dataCount);
 
     outStream.write((char*)&count, sizeof(uint8_t));
     for (std::size_t iFlat = dataStart; iFlat < dataEnd; ++iFlat) {
@@ -826,7 +826,7 @@ public:
   bool hasPropertyType(const std::string& target) const {
     for (const std::unique_ptr<Property>& prop : properties) {
       if (prop->name == target) {
-        TypedProperty<T>* castedProp = dynamic_cast<TypedProperty<T>*>(prop.get());
+        auto* castedProp = dynamic_cast<TypedProperty<T>*>(prop.get());
         if (castedProp) {
           return true;
         }
@@ -959,7 +959,7 @@ public:
 
     // Find the property
     std::unique_ptr<Property>& prop = getPropertyPtr(propertyName);
-    TypedProperty<T>* castedProp = dynamic_cast<TypedProperty<T>*>(prop.get());
+    auto* castedProp = dynamic_cast<TypedProperty<T>*>(prop.get());
     if (castedProp) {
       return castedProp->data;
     }
@@ -1002,7 +1002,7 @@ public:
 
     // Find the property
     std::unique_ptr<Property>& prop = getPropertyPtr(propertyName);
-    TypedListProperty<T>* castedProp = dynamic_cast<TypedListProperty<T>*>(prop.get());
+    auto* castedProp = dynamic_cast<TypedListProperty<T>*>(prop.get());
     if (castedProp) {
       return unflattenList(castedProp->flattenedData, castedProp->flattenedIndexStart);
     }
@@ -1165,7 +1165,7 @@ public:
     typedef typename CanonicalName<T>::type Tcan;
 
     { // Try to return data of type D from a property of type T
-      TypedProperty<Tcan>* castedProp = dynamic_cast<TypedProperty<Tcan>*>(prop);
+      auto* castedProp = dynamic_cast<TypedProperty<Tcan>*>(prop);
       if (castedProp) {
         // Succeeded, return a buffer of the data (copy while converting type)
         std::vector<D> castedVec;
@@ -1202,7 +1202,7 @@ public:
   std::vector<std::vector<D>> getDataFromListPropertyRecursive(Property* prop) {
     typedef typename CanonicalName<T>::type Tcan;
 
-    TypedListProperty<Tcan>* castedProp = dynamic_cast<TypedListProperty<Tcan>*>(prop);
+    auto* castedProp = dynamic_cast<TypedListProperty<Tcan>*>(prop);
     if (castedProp) {
       // Succeeded, return a buffer of the data (copy while converting type)
 
@@ -1641,7 +1641,7 @@ public:
     for (std::vector<T>& l : indices) {
       std::vector<IndType> thisInds;
       for (T& val : l) {
-        IndType valConverted = static_cast<IndType>(val);
+        auto valConverted = static_cast<IndType>(val);
         if (valConverted != val) {
           throw std::runtime_error("Index value " + std::to_string(val) +
                                    " could not be converted to a .ply integer without loss of data. Note that .ply "

--- a/happly.h
+++ b/happly.h
@@ -1556,7 +1556,7 @@ public:
    *
    * @param colors A vector of vertex colors (unsigned chars [0,255]).
    */
-  void addVertexColors(std::vector<std::array<unsigned char, 3>>& colors) {
+  void addVertexColors(const std::vector<std::array<unsigned char, 3>>& colors) {
 
     const std::string vertexName = "vertex";
     const std::size_t N = colors.size();
@@ -1587,7 +1587,7 @@ public:
    *
    * @param colors A vector of vertex colors as floating point [0,1] values. Internally converted to [0,255] chars.
    */
-  void addVertexColors(std::vector<std::array<double, 3>>& colors) {
+  void addVertexColors(const std::vector<std::array<double, 3>>& colors) {
 
     std::string vertexName = "vertex";
     std::size_t N = colors.size();

--- a/happly.h
+++ b/happly.h
@@ -1525,7 +1525,7 @@ public:
    *
    * @param vertexPositions A vector of vertex positions
    */
-  void addVertexPositions(std::vector<std::array<double, 3>>& vertexPositions) {
+  void addVertexPositions(const std::vector<std::array<double, 3>>& vertexPositions) {
 
     const std::string vertexName{"vertex"};
     const std::size_t N = vertexPositions.size();

--- a/happly.h
+++ b/happly.h
@@ -1258,14 +1258,14 @@ inline std::vector<std::string> tokenSplit(const std::string& input) {
   while ((found = input.find_first_of(' ', curr)) != std::string::npos) {
     std::string token = input.substr(curr, found - curr);
     token = trimSpaces(token);
-    if (token.size() > 0) {
+    if (!token.empty()) {
       result.push_back(token);
     }
     curr = found + 1;
   }
   std::string token = input.substr(curr);
   token = trimSpaces(token);
-  if (token.size() > 0) {
+  if (!token.empty()) {
     result.push_back(token);
   }
 

--- a/happly.h
+++ b/happly.h
@@ -138,7 +138,7 @@ public:
    *
    * @param capacity Expected number of elements.
    */
-  virtual void reserve(size_t capacity) = 0;
+  virtual void reserve(std::size_t capacity) = 0;
 
   /**
    * @brief (ASCII reading) Parse out the next value of this property from a list of tokens.
@@ -146,7 +146,7 @@ public:
    * @param tokens The list of property tokens for the element.
    * @param currEntry Index in to tokens, updated after this property is read.
    */
-  virtual void parseNext(const std::vector<std::string>& tokens, size_t& currEntry) = 0;
+  virtual void parseNext(const std::vector<std::string>& tokens, std::size_t& currEntry) = 0;
 
   /**
    * @brief (binary reading) Copy the next value of this property from a stream of bits.
@@ -175,7 +175,7 @@ public:
    * @param outStream Stream to write to.
    * @param iElement index of the element to write.
    */
-  virtual void writeDataASCII(std::ostream& outStream, size_t iElement) = 0;
+  virtual void writeDataASCII(std::ostream& outStream, std::size_t iElement) = 0;
 
   /**
    * @brief (binary writing) copy the bits of this property for some element to a stream
@@ -183,7 +183,7 @@ public:
    * @param outStream Stream to write to.
    * @param iElement index of the element to write.
    */
-  virtual void writeDataBinary(std::ostream& outStream, size_t iElement) = 0;
+  virtual void writeDataBinary(std::ostream& outStream, std::size_t iElement) = 0;
 
   /**
    * @brief (binary writing) copy the bits of this property for some element to a stream
@@ -191,14 +191,14 @@ public:
    * @param outStream Stream to write to.
    * @param iElement index of the element to write.
    */
-  virtual void writeDataBinaryBigEndian(std::ostream& outStream, size_t iElement) = 0;
+  virtual void writeDataBinaryBigEndian(std::ostream& outStream, std::size_t iElement) = 0;
 
   /**
    * @brief Number of element entries for this property
    *
    * @return
    */
-  virtual size_t size() = 0;
+  virtual std::size_t size() = 0;
 
   /**
    * @brief A string naming the type of the property
@@ -391,7 +391,7 @@ public:
    *
    * @return
    */
-  virtual size_t size() override { return data.size(); }
+  std::size_t size() override { return data.size(); }
 
 
   /**
@@ -470,14 +470,14 @@ public:
   virtual void parseNext(const std::vector<std::string>& tokens, size_t& currEntry) override {
 
     std::istringstream iss(tokens[currEntry]);
-    size_t count;
+    std::size_t count;
     iss >> count;
     currEntry++;
 
-    size_t currSize = flattenedData.size();
-    size_t afterSize = currSize + count;
+    const std::size_t currSize = flattenedData.size();
+    std::size_t afterSize = currSize + count;
     flattenedData.resize(afterSize);
-    for (size_t iFlat = currSize; iFlat < afterSize; iFlat++) {
+    for (std::size_t iFlat = currSize; iFlat < afterSize; iFlat++) {
       std::istringstream iss(tokens[currEntry]);
       typename SerializeType<T>::type tmp; // usually the same type as T
       iss >> tmp;
@@ -495,12 +495,12 @@ public:
   virtual void readNext(std::istream& stream) override {
 
     // Read the size of the list
-    size_t count = 0;
+    std::size_t count = 0;
     stream.read(((char*)&count), listCountBytes);
 
     // Read list elements
-    size_t currSize = flattenedData.size();
-    size_t afterSize = currSize + count;
+    std::size_t currSize = flattenedData.size();
+    std::size_t afterSize = currSize + count;
     flattenedData.resize(afterSize);
     if (count > 0) {
       stream.read((char*)&flattenedData[currSize], count * sizeof(T));
@@ -516,7 +516,7 @@ public:
   virtual void readNextBigEndian(std::istream& stream) override {
 
     // Read the size of the list
-    size_t count = 0;
+    std::size_t count = 0;
     stream.read(((char*)&count), listCountBytes);
     if (listCountBytes == 8) {
       count = (size_t)swapEndian((uint64_t)count);
@@ -527,8 +527,8 @@ public:
     }
 
     // Read list elements
-    size_t currSize = flattenedData.size();
-    size_t afterSize = currSize + count;
+    std::size_t currSize = flattenedData.size();
+    std::size_t afterSize = currSize + count;
     flattenedData.resize(afterSize);
     if (count > 0) {
       stream.read((char*)&flattenedData[currSize], count * sizeof(T));
@@ -557,12 +557,12 @@ public:
    * @param outStream Stream to write to.
    * @param iElement index of the element to write.
    */
-  virtual void writeDataASCII(std::ostream& outStream, size_t iElement) override {
-    size_t dataStart = flattenedIndexStart[iElement];
-    size_t dataEnd = flattenedIndexStart[iElement + 1];
+  void writeDataASCII(std::ostream& outStream, std::size_t iElement) override {
+    std::size_t dataStart = flattenedIndexStart[iElement];
+    std::size_t dataEnd = flattenedIndexStart[iElement + 1];
 
     // Get the number of list elements as a uchar, and ensure the value fits
-    size_t dataCount = dataEnd - dataStart;
+    std::size_t dataCount = dataEnd - dataStart;
     if (dataCount > std::numeric_limits<uint8_t>::max()) {
       throw std::runtime_error(
           "List property has an element with more entries than fit in a uchar. See note in README.");
@@ -581,12 +581,12 @@ public:
    * @param outStream Stream to write to.
    * @param iElement index of the element to write.
    */
-  virtual void writeDataBinary(std::ostream& outStream, size_t iElement) override {
-    size_t dataStart = flattenedIndexStart[iElement];
-    size_t dataEnd = flattenedIndexStart[iElement + 1];
+  void writeDataBinary(std::ostream& outStream, std::size_t iElement) override {
+    std::size_t dataStart = flattenedIndexStart[iElement];
+    std::size_t dataEnd = flattenedIndexStart[iElement + 1];
 
     // Get the number of list elements as a uchar, and ensure the value fits
-    size_t dataCount = dataEnd - dataStart;
+    std::size_t dataCount = dataEnd - dataStart;
     if (dataCount > std::numeric_limits<uint8_t>::max()) {
       throw std::runtime_error(
           "List property has an element with more entries than fit in a uchar. See note in README.");
@@ -608,7 +608,7 @@ public:
     size_t dataEnd = flattenedIndexStart[iElement + 1];
 
     // Get the number of list elements as a uchar, and ensure the value fits
-    size_t dataCount = dataEnd - dataStart;
+    std::size_t dataCount = dataEnd - dataStart;
     if (dataCount > std::numeric_limits<uint8_t>::max()) {
       throw std::runtime_error(
           "List property has an element with more entries than fit in a uchar. See note in README.");
@@ -647,7 +647,7 @@ public:
    * @brief Indices in to flattenedData. The i'th element gives the index in to flattenedData where the element's data
    * begins. A final entry is included which is the length of flattenedData. Size is N_elem + 1.
    */
-  std::vector<size_t> flattenedIndexStart;
+  std::vector<std::size_t> flattenedIndexStart{};
 
   /**
    * @brief The number of bytes used to store the count for lists of data.
@@ -787,7 +787,7 @@ public:
   Element(const std::string& name_, size_t count_) : name(name_), count(count_) {}
 
   std::string name;
-  size_t count;
+  std::size_t count;
   std::vector<std::unique_ptr<Property>> properties;
 
   /**
@@ -1235,17 +1235,17 @@ public:
 namespace {
 
 inline std::string trimSpaces(const std::string& input) {
-  size_t start = 0;
+  std::size_t start = 0;
   while (start < input.size() && input[start] == ' ') start++;
-  size_t end = input.size();
+  std::size_t end = input.size();
   while (end > start && (input[end - 1] == ' ' || input[end - 1] == '\n' || input[end - 1] == '\r')) end--;
   return input.substr(start, end - start);
 }
 
 inline std::vector<std::string> tokenSplit(const std::string& input) {
   std::vector<std::string> result;
-  size_t curr = 0;
-  size_t found = 0;
+  std::size_t curr = 0;
+  std::size_t found = 0;
   while ((found = input.find_first_of(' ', curr)) != std::string::npos) {
     std::string token = input.substr(curr, found - curr);
     token = trimSpaces(token);
@@ -1436,7 +1436,7 @@ public:
    * @param name The name of the new element type ("vertices").
    * @param count The number of elements of this type.
    */
-  void addElement(const std::string& name, size_t count) { elements.emplace_back(name, count); }
+  void addElement(const std::string& name, std::size_t count) { elements.emplace_back(name, count); }
 
   // === Common-case helpers
 
@@ -1488,13 +1488,13 @@ public:
   }
 
   /**
-   * @brief Common-case helper to get face indices for a mesh. If not template type is given, size_t is used. Naively
+   * @brief Common-case helper to get face indices for a mesh. If not template type is given, std::size_t is used. Naively
    * converts to requested signedness, which may lead to unexpected values if an unsigned type is used and file contains
    * negative values.
    *
    * @return The indices into the vertex elements for each face. Usually 0-based, though there are no formal rules.
    */
-  template <typename T = size_t>
+  template <typename T = std::size_t>
   std::vector<std::vector<T>> getFaceIndices() {
 
     for (const std::string& f : std::vector<std::string>{"face"}) {
@@ -1580,7 +1580,7 @@ public:
   void addVertexColors(std::vector<std::array<double, 3>>& colors) {
 
     std::string vertexName = "vertex";
-    size_t N = colors.size();
+    std::size_t N = colors.size();
 
     // Create the element
     if (!hasElement(vertexName)) {
@@ -1778,7 +1778,7 @@ private:
         vector<string> tokens = tokenSplit(line);
         if (tokens.size() != 3) throw std::runtime_error("PLY parser: Invalid element line");
         string name = tokens[1];
-        size_t count;
+        std::size_t count;
         std::istringstream iss(tokens[2]);
         iss >> count;
         elements.emplace_back(name, count);

--- a/happly.h
+++ b/happly.h
@@ -88,9 +88,9 @@ template<> inline std::string typeName<float>()             { return "float";   
 template<> inline std::string typeName<double>()            { return "double";  }
 
 // Template hackery that makes getProperty<T>() and friends pretty while automatically picking up smaller types
-namespace {
+inline namespace details {
 
-// A pointer for the equivalent/smaller equivalent of a type (eg. when a double is requested a float works too, etc)
+// A pointer for the equivalent/smaller equivalent of a type (e.g. when a double is requested, a float works too, etc)
 // long int is intentionally absent to avoid platform confusion
 template <class T> struct TypeChain                 { bool hasChildType = false;   typedef T            type; };
 template <> struct TypeChain<int64_t>               { bool hasChildType = true;    typedef int32_t      type; };
@@ -216,7 +216,7 @@ public:
   virtual std::string propertyTypeName() = 0;
 };
 
-namespace {
+inline namespace details {
 
 /**
  * Check if the platform is little endian.
@@ -224,7 +224,7 @@ namespace {
  *
  * @return true if little endian
  */
-bool isLittleEndian() {
+inline bool isLittleEndian() {
   int32_t oneVal = 0x1;
   const auto numPtr = reinterpret_cast<char*>(&oneVal);
   return (numPtr[0] == 1);
@@ -247,8 +247,8 @@ T swapEndian(T val) {
 }
 
 // The following specializations for single-byte types are used to avoid compiler warnings.
-template <> int8_t swapEndian<int8_t>(int8_t val) { return val; }
-template <> uint8_t swapEndian<uint8_t>(uint8_t val) { return val; }
+template <> inline int8_t swapEndian<int8_t>(int8_t val) { return val; }
+template <> inline uint8_t swapEndian<uint8_t>(uint8_t val) { return val; }
 
 
 // Unpack flattened list from the convention used in TypedListProperty
@@ -1241,7 +1241,7 @@ public:
 
 
 // Some string helpers
-namespace {
+inline namespace details {
 
 inline std::string trimSpaces(const std::string& input) {
   std::size_t start = 0;

--- a/happly.h
+++ b/happly.h
@@ -792,7 +792,7 @@ public:
    * @param name_ Name of the element type (eg, "vertices")
    * @param count_ Number of instances of this element.
    */
-  Element(const std::string& name_, size_t count_) : name(name_), count(count_) {}
+  Element(const std::string& name_, std::size_t count_) : name(name_), count(count_) {}
 
   std::string name;
   std::size_t count;
@@ -1287,7 +1287,7 @@ public:
   /**
    * @brief Create an empty PLYData object.
    */
-  PLYData(){};
+  PLYData() = default;
 
   /**
    * @brief Initialize a PLYData by reading from a file. Throws if any failures occur.
@@ -2000,7 +2000,7 @@ private:
 
     // Write comments
     bool hasHapplyComment = false;
-    std::string happlyComment = "Written with hapPLY (https://github.com/nmwsharp/happly)";
+    const std::string happlyComment{"Written with hapPLY (https://github.com/nmwsharp/happly)"};
     for (const std::string& comment : comments) {
       if (comment == happlyComment) hasHapplyComment = true;
       outStream << "comment " << comment << "\n";

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.20)
 
 project(happly-test)
 

--- a/test/CMakeLists.txt.in
+++ b/test/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION 3.20)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
Hi, this PR cleans up a little bit the code with minor changes:

* constness for variables, function arguments, and methods
* avoid c-style casting but rather use static or reinterpret cast
* use range loops where possible
* remove `virtual`from overridden methods as it is not necessary
* use `default` for empty constructors/destructors
* use `make_unique()` instead of allocating explicitly with `new`
* define an `implicit namespace detail` instead of an anonymous namespace
* use `empty()` instead of checking `size() == 0` for containers 

I also had to raise the minimum CMake version because on recent versions the minimum that was required is not supported anymore.

I have some other code improvements requiring C++20 standard (concepts, ranges algo etc), if you are interested I can make another PR after this.
Also the CMakeLists for testing can be simplified quite a bit using fetch_content to retrieve the GTest automatically. I can make a PR about that too.