### PR TITLE
Address a crash when trying to reserve space for a massive number of elements.

### DIFF
--- a/happly.h
+++ b/happly.h
@@ -307,7 +307,19 @@ public:
    *
    * @param capacity Expected number of elements.
    */
-  virtual void reserve(size_t capacity) override { data.reserve(capacity); }
+  virtual void reserve(size_t capacity) override { 
+    try {
+      data.reserve(capacity); 
+    }
+    catch (const std::bad_alloc& e) {
+      throw std::runtime_error("Failed to reserve memory for " +
+                               std::to_string(capacity) +
+                               " elements: " + e.what());
+    } catch (const std::length_error& e) {
+      throw std::runtime_error("Requested capacity " + std::to_string(capacity) + 
+                               " is too large for reserve(): " + e.what());
+    }
+  }
 
   /**
    * @brief (ASCII reading) Parse out the next value of this property from a list of tokens.
@@ -457,8 +469,18 @@ public:
    * @param capacity Expected number of elements.
    */
   virtual void reserve(size_t capacity) override {
-    flattenedData.reserve(3 * capacity); // optimize for triangle meshes
-    flattenedIndexStart.reserve(capacity + 1);
+    try {
+      flattenedData.reserve(3 * capacity); // optimize for triangle meshes
+      flattenedIndexStart.reserve(capacity + 1);
+    }
+    catch (const std::bad_alloc& e) {
+      throw std::runtime_error("Failed to reserve memory for " +
+                               std::to_string(capacity) +
+                               " elements: " + e.what());
+    } catch (const std::length_error& e) {
+      throw std::runtime_error("Requested capacity " + std::to_string(capacity) + 
+                               " is too large for reserve(): " + e.what());
+    }
   }
 
   /**
@@ -476,7 +498,14 @@ public:
 
     size_t currSize = flattenedData.size();
     size_t afterSize = currSize + count;
-    flattenedData.resize(afterSize);
+    try {
+      flattenedData.resize(afterSize);
+    }
+    catch (const std::bad_alloc& e) {
+      throw std::runtime_error("Failed to size to " + std::to_string(afterSize) + e.what());
+    } catch (const std::length_error& e) {
+      throw std::runtime_error("Failed to size to " + std::to_string(afterSize) + e.what());
+    }
     for (size_t iFlat = currSize; iFlat < afterSize; iFlat++) {
       std::istringstream iss(tokens[currEntry]);
       typename SerializeType<T>::type tmp; // usually the same type as T


### PR DESCRIPTION
Fixes #48 and a similar issue where `resize` could similarly cause a crash. It catches the error and rethrows it as a runtime error. I don't know how helpful this is, but at least it now matches the other types of errors happly throws.

I think the ideal would be to abort before we try to `reserve` or `resize`, but I don't know the best way to do that.