### PR TITLE
Add bounds verification in parseNext

### DIFF
--- a/happly.h
+++ b/happly.h
@@ -316,6 +316,9 @@ public:
    * @param currEntry Index in to tokens, updated after this property is read.
    */
   virtual void parseNext(const std::vector<std::string>& tokens, size_t& currEntry) override {
+    if (currEntry >= tokens.size()) {
+      throw std::runtime_error("PLY parser: missing token for property");
+    }
     data.emplace_back();
     std::istringstream iss(tokens[currEntry]);
     typename SerializeType<T>::type tmp; // usually the same type as T
@@ -468,7 +471,9 @@ public:
    * @param currEntry Index in to tokens, updated after this property is read.
    */
   virtual void parseNext(const std::vector<std::string>& tokens, size_t& currEntry) override {
-
+    if (currEntry >= tokens.size()) {
+      throw std::runtime_error("PLY parser: missing token for property");
+    }
     std::istringstream iss(tokens[currEntry]);
     size_t count;
     iss >> count;
@@ -478,6 +483,9 @@ public:
     size_t afterSize = currSize + count;
     flattenedData.resize(afterSize);
     for (size_t iFlat = currSize; iFlat < afterSize; iFlat++) {
+      if (currEntry >= tokens.size()) {
+        throw std::runtime_error("PLY parser: missing token for property");
+      }
       std::istringstream iss(tokens[currEntry]);
       typename SerializeType<T>::type tmp; // usually the same type as T
       iss >> tmp;


### PR DESCRIPTION
Fixes #49 by adding bounds verification in `parseNext` and throwing an error if we go out of bounds.