### PR TITLE
Include cstdint explicitly for uint8_t etc.

### DIFF
--- a/happly.h
+++ b/happly.h
@@ -50,6 +50,7 @@ SOFTWARE.
 
 #include <array>
 #include <cctype>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
 #include <limits>


### PR DESCRIPTION
This is required due to errors on recent platforms of type `'uint8_t' was not declared in this scope`: https://github.com/2xB/Kassiopeia/actions/runs/24627175671/job/72008132776?pr=21